### PR TITLE
Feat: Add GitHub Actions workflows for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: C++ CI 
+  
+on:  
+  push:  
+    branches: [ main, master ]  
+  pull_request:  
+    branches: [ main, master ]  
+  
+jobs:  
+  build:  
+    runs-on: ubuntu-latest  
+  
+    steps:  
+    - uses: actions/checkout@v3  
+  
+    - name: Install dependencies  
+      run: |  
+        sudo apt-get update  
+        sudo apt-get install -y g++ make  
+  
+    - name: Build  
+      run: make  
+  
+    - name: Archive production artifacts  
+      uses: actions/upload-artifact@v3  
+      with:  
+        name: dungeon-executable  
+        path: dungeon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,28 @@
 name: C++ CI 
-  
+
 on:  
   push:  
     branches: [ main, master ]  
   pull_request:  
     branches: [ main, master ]  
-  
+
 jobs:  
   build:  
     runs-on: ubuntu-latest  
-  
+
     steps:  
     - uses: actions/checkout@v3  
-  
+
     - name: Install dependencies  
       run: |  
         sudo apt-get update  
         sudo apt-get install -y g++ make  
-  
+
     - name: Build  
       run: make  
-  
+
     - name: Archive production artifacts  
-      uses: actions/upload-artifact@v3  
+      uses: actions/upload-artifact@v4
       with:  
         name: dungeon-executable  
         path: dungeon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release  
+  
+on:  
+  push:  
+    tags:  
+      - 'v*'  
+  
+jobs:  
+  build:  
+    runs-on: ubuntu-latest  
+  
+    steps:  
+    - uses: actions/checkout@v3  
+  
+    - name: Install dependencies  
+      run: |  
+        sudo apt-get update  
+        sudo apt-get install -y g++ make  
+  
+    - name: Build  
+      run: make  
+  
+    - name: Create Release  
+      id: create_release  
+      uses: actions/create-release@v1  
+      env:  
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+      with:  
+        tag_name: ${{ github.ref }}  
+        release_name: Release ${{ github.ref }}  
+        draft: false  
+        prerelease: false  
+  
+    - name: Upload Release Asset  
+      uses: actions/upload-release-asset@v1  
+      env:  
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+      with:  
+        upload_url: ${{ steps.create_release.outputs.upload_url }}  
+        asset_path: ./dungeon  
+        asset_name: dungeon  
+        asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,8 @@ jobs:
       env:  
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
       with:  
-        tag_name: ${{ github.ref }}  
-        release_name: Release ${{ github.ref }}  
-        draft: false  
+        tag_name: ${{ github.ref_name }}
+        release_name: Release ${{ github.ref_name }}
         prerelease: false  
   
     - name: Upload Release Asset  


### PR DESCRIPTION
This pull request introduces two GitHub Actions workflows to automate the CI/CD pipeline for a C++ project. The first workflow handles continuous integration (CI) for building and testing code on pushes and pull requests, while the second workflow automates the release process by creating GitHub releases and uploading build artifacts when a new tag is pushed.

### CI Workflow:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R28): Added a CI workflow to build the project on `ubuntu-latest` for pushes and pull requests to the `main` and `master` branches. It includes steps for checking out the code, installing dependencies (`g++` and `make`), building the project using `make`, and archiving the build artifacts.

### Release Workflow:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R42): Added a release workflow triggered by tags matching the pattern `v*`. It builds the project, creates a GitHub release with the tag, and uploads the build artifact (`dungeon`) to the release.